### PR TITLE
fix(vexhub): use correct urls for vexhub files

### DIFF
--- a/trivy_vexhub/index.json
+++ b/trivy_vexhub/index.json
@@ -3,7 +3,7 @@
   "packages": [
     {
       "id": "pkg:generic/python@3.13.7",
-      "location": "pkg/generic/python",
+      "location": "pkg/generic/python/vex.json",
       "format": "openvex"
     }
   ]

--- a/vex-repository.json
+++ b/vex-repository.json
@@ -5,7 +5,9 @@
     {
       "spec_version": "0.1",
       "locations": [
-        "RepositoryLocation(url='https://github.com/ActiveState/advisories.tar.gz//trivy_vexhub')"
+        {
+          "url": "https://github.com/ActiveState/advisories/archive/refs/heads/main.tar.gz//advisories-main/trivy_vexhub"
+        }
       ],
       "update_interval": "12h"
     }


### PR DESCRIPTION
## Description
This PR fixes 2 problem with vexhub files:
1. Use `url` structs for `vex-repository.json` file - https://github.com/aquasecurity/vex-repo-spec/blob/b795dc2403cc825956b6bb197c55734c1728f761/vex-repository.schema.json#L31-L35
2. Use path to VEX file (instead of dir) in index.json file 